### PR TITLE
Docker Jib config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,18 @@
 					</excludes>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.0</version>
+				<configuration>
+					<from>
+						<image>eclipse-temurin:21-jre-ubi9-minimal</image>
+					</from>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/src/main/jib/SpaceshipComponents.json
+++ b/src/main/jib/SpaceshipComponents.json
@@ -1,0 +1,167 @@
+[
+  {
+    "spaceshipName": "Falcon-X",
+    "title": "Hyperdrive Core",
+    "description": "A high-performance hyperdrive core capable of intergalactic travel.",
+    "price": 250000,
+    "timeToBuild": "14 days",
+    "features": "Enables faster-than-light travel; Advanced fuel efficiency; Compatible with most spaceship models.",
+    "keywords": "Hyperdrive, FTL, Engine, Space Travel",
+    "spaceshipType": "Battleship",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Star Defender",
+    "title": "Quantum Shield Generator",
+    "description": "A powerful energy shield system that can absorb enemy fire and reduce impact damage.",
+    "price": 150000,
+    "timeToBuild": "10 days",
+    "features": "Multi-layered shielding; Rechargeable energy cores; Customizable field strength.",
+    "keywords": "Shield, Defense, Energy Barrier, Protection",
+    "spaceshipType": "Transport",
+    "spaceshipSize": "Medium"
+  },
+  {
+    "spaceshipName": "Rogue Phoenix",
+    "title": "Plasma Weapon Turret",
+    "description": "A high-energy plasma turret that delivers devastating firepower.",
+    "price": 100000,
+    "timeToBuild": "7 days",
+    "features": "Auto-tracking system; Adjustable plasma beam intensity; Rapid-fire mode.",
+    "keywords": "Plasma, Weapon, Defense, Turret",
+    "spaceshipType": "Scout",
+    "spaceshipSize": "Small"
+  },
+  {
+    "spaceshipName": "Galactic Explorer",
+    "title": "Advanced Life Support System",
+    "description": "Provides oxygen circulation, temperature regulation, and emergency survival systems.",
+    "price": 75000,
+    "timeToBuild": "5 days",
+    "features": "Oxygen recycling; Emergency escape pod integration; Automated medical response.",
+    "keywords": "Life Support, Oxygen, Safety, Space Travel",
+    "spaceshipType": "Varies",
+    "spaceshipSize": "Medium"
+  },
+  {
+    "spaceshipName": "Nebula Cruiser",
+    "title": "AI Navigation System",
+    "description": "A next-gen artificial intelligence system for autonomous piloting and navigation.",
+    "price": 175000,
+    "timeToBuild": "12 days",
+    "features": "AI-assisted navigation; Obstacle avoidance; Adaptive route planning.",
+    "keywords": "AI, Navigation, Autopilot, Space Travel",
+    "spaceshipType": "Transport",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Falcon-X",
+    "title": "Stealth Coating",
+    "description": "A specialized nano-coating that absorbs radar and light waves for stealth operations.",
+    "price": 200000,
+    "timeToBuild": "8 days",
+    "features": "Reduces visibility; Radar absorption; Minimal energy signature.",
+    "keywords": "Stealth, Cloaking, Defense, Spy",
+    "spaceshipType": "Scout",
+    "spaceshipSize": "Small"
+  },
+  {
+    "spaceshipName": "Star Defender",
+    "title": "Warp Core Reactor",
+    "description": "A high-capacity reactor that provides energy for long-range warp travel.",
+    "price": 300000,
+    "timeToBuild": "15 days",
+    "features": "High energy output; Low heat dissipation; Warp drive compatible.",
+    "keywords": "Warp Drive, Energy, Reactor, Fuel",
+    "spaceshipType": "Battleship",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Rogue Phoenix",
+    "title": "Gravitational Field Stabilizer",
+    "description": "Enhances spaceship stability in high-gravity environments.",
+    "price": 120000,
+    "timeToBuild": "9 days",
+    "features": "Counteracts gravitational fluctuations; Improves maneuverability in heavy gravity zones.",
+    "keywords": "Gravity, Stabilizer, Maneuverability, Space Physics",
+    "spaceshipType": "Varies",
+    "spaceshipSize": "Medium"
+  },
+  {
+    "spaceshipName": "Galactic Explorer",
+    "title": "Ion Thrusters",
+    "description": "Efficient propulsion system for deep-space travel.",
+    "price": 180000,
+    "timeToBuild": "11 days",
+    "features": "Low fuel consumption; Silent operation; Extended durability.",
+    "keywords": "Ion, Thruster, Propulsion, Space Travel",
+    "spaceshipType": "Transport",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Nebula Cruiser",
+    "title": "Holographic Control Panel",
+    "description": "A fully interactive holographic command interface.",
+    "price": 95000,
+    "timeToBuild": "6 days",
+    "features": "Touch-free controls; Customizable interface; AI-assisted system monitoring.",
+    "keywords": "Holographic, UI, Controls, AI",
+    "spaceshipType": "Scout",
+    "spaceshipSize": "Small"
+  },
+  {
+    "spaceshipName": "Falcon-X",
+    "title": "Cryogenic Stasis Chamber",
+    "description": "Allows crew members to enter deep sleep for long-duration missions.",
+    "price": 220000,
+    "timeToBuild": "13 days",
+    "features": "Temperature-regulated sleep pods; Emergency wake-up protocols.",
+    "keywords": "Cryogenic, Stasis, Deep Space, Crew Safety",
+    "spaceshipType": "Transport",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Star Defender",
+    "title": "Neutrino Communication Array",
+    "description": "Enables instant communication across vast distances using neutrino signals.",
+    "price": 200000,
+    "timeToBuild": "10 days",
+    "features": "Faster-than-light communication; Immune to signal jamming.",
+    "keywords": "Neutrino, Communication, Intergalactic, Signal",
+    "spaceshipType": "Varies",
+    "spaceshipSize": "Medium"
+  },
+  {
+    "spaceshipName": "Rogue Phoenix",
+    "title": "Emergency Escape Pod",
+    "description": "A self-contained escape pod equipped with survival gear.",
+    "price": 60000,
+    "timeToBuild": "4 days",
+    "features": "Autonomous navigation; Reinforced hull; Emergency beacon.",
+    "keywords": "Escape Pod, Safety, Survival, Emergency",
+    "spaceshipType": "Scout",
+    "spaceshipSize": "Small"
+  },
+  {
+    "spaceshipName": "Galactic Explorer",
+    "title": "Dark Matter Core",
+    "description": "Experimental energy source harnessing dark matter for limitless power.",
+    "price": 500000,
+    "timeToBuild": "20 days",
+    "features": "Near-infinite energy output; Zero emissions; Unstable at high power levels.",
+    "keywords": "Dark Matter, Energy, Reactor, Power",
+    "spaceshipType": "Battleship",
+    "spaceshipSize": "Large"
+  },
+  {
+    "spaceshipName": "Nebula Cruiser",
+    "title": "Micro-Tachyon Scanner",
+    "description": "Advanced scanning device capable of detecting hidden celestial objects.",
+    "price": 135000,
+    "timeToBuild": "7 days",
+    "features": "Detects cloaked ships; Maps dark matter fields; High-resolution deep-space scans.",
+    "keywords": "Tachyon, Scanner, Deep Space, Detection",
+    "spaceshipType": "Scout",
+    "spaceshipSize": "Small"
+  }
+]


### PR DESCRIPTION
Added Docker (Jib) configuration to pom.xml. Copied the spaceship json data file into the jib repository so the file is available inside the docker container when it is started. The basic set of commands to use with Docker (jib): mvn jib:dockerBuild (creates the image), docker image (shows created images), docker run -p 8080:8080 spaceship-data:0.0.1-SNAPSHOT (spins a container from the image, maps to localhost:8080), docker ps -a (shows running containers), docker stop dcfd0d54a6dd (stops the container by id), docker rm dcfd0d54a6dd (removes the container by id), docker images (shows images), docker rmi spaceship-data:0.0.1-SNAPSHOT (removes image).